### PR TITLE
Upgrade flow to 0.48

### DIFF
--- a/extensions/roc-plugin-flow/package.json
+++ b/extensions/roc-plugin-flow/package.json
@@ -21,7 +21,7 @@
   "repository": "https://github.com/baseonmars/roc-plugin-flow/tree/master/extensions/roc-plugin-flow",
   "dependencies": {
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "flow-bin": "0.47.0",
+    "flow-bin": "0.48.0",
     "roc": "^1.0.0-rc.20"
   },
   "devDependencies": {


### PR DESCRIPTION
Flow 0.48 has removed the dependency on `libelf`, making it easier to run in containerized environments.

Fixes #8